### PR TITLE
Setup `sonner` toaster with a custom hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,11 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.396.0",
         "next": "14.2.4",
+        "next-themes": "^0.3.0",
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.53.0",
+        "sonner": "^1.5.0",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.8"
@@ -1698,6 +1700,15 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.3.0.tgz",
+      "integrity": "sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w==",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -2181,6 +2192,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.5.0.tgz",
+      "integrity": "sha512-FBjhG/gnnbN6FY0jaNnqZOMmB73R+5IiyYAw8yBj7L54ER7HB3fOSE5OFiQiE2iXWxeXKvg6fIP4LtVppHEdJA==",
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.396.0",
     "next": "14.2.4",
+    "next-themes": "^0.3.0",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.53.0",
+    "sonner": "^1.5.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.8"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import ReactQueryProvider from "@/components/ReactQueryProvider";
 import Header from "@/components/header/Header";
 import { PropsWithChildren } from "react";
+import { Toaster } from "@/components/ui/sonner";
 
 const fontSans = Inter({
   subsets: ["latin"],
@@ -32,6 +33,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
             <main className="flex h-full flex-1">
               {children}
             </main>
+            <Toaster />
           </TooltipProvider>
         </ReactQueryProvider>
       </body>

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner } from "sonner"
+
+type ToasterProps = React.ComponentProps<typeof Sonner>
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton:
+            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+          cancelButton:
+            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/hook/useSonnerToast.tsx
+++ b/src/hook/useSonnerToast.tsx
@@ -1,0 +1,29 @@
+import { ExternalToast, toast } from "sonner";
+
+type FeedbackVariants = "error" | "info" | "success" | "warning";
+
+type SonnerToastProps = {
+  title: string;
+  description?: string;
+  variant: FeedbackVariants;
+};
+
+const variantsColors: Record<FeedbackVariants, string> = {
+  error: "text-red-700",
+  info: "text-blue-600",
+  warning: "text-yellow-700",
+  success: "text-green-500",
+};
+
+export default function useSonnerToast() {
+  return ({ title, variant, description }: SonnerToastProps) => {
+    const config: ExternalToast = {
+      description,
+      className: 'items-start',
+      classNames: {
+        icon: `m-0 mt-1 ${variantsColors[variant]}`,
+      }
+    }
+    toast[variant](title, config);
+  };
+}


### PR DESCRIPTION
Setup `sonner` toaster with a custom hook by 👇 

* Add `sonner` toaster by `npx shadcn@latest add sonner`.

* Add `sonner` toaster's container to the root layout.

* Create `src/hook/useToast.tsx` hook for customizing the toaster of `sonner` package 
and providing a custom API to fire toasters. The customization for now is to paint the icon 
of `sonner`'s toaster based of the type or the variant of the toaster whether is "error", "info, 
"success" or "warning".
