### PR TITLE
Refactor the custom fetch API

### DIFF
--- a/src/lib/FetchError.ts
+++ b/src/lib/FetchError.ts
@@ -1,0 +1,9 @@
+export default class FetchError<ErrorT = unknown> extends Error {
+  status: number | undefined;
+  error: ErrorT | undefined;
+  constructor(message: string, details?: ErrorDetails<ErrorT> & ErrorOptions) {
+    super(message, { cause: details?.cause });
+    this.status = details?.status;
+    this.error = details?.error;
+  }
+}

--- a/src/lib/customFetchAPI.ts
+++ b/src/lib/customFetchAPI.ts
@@ -1,0 +1,42 @@
+"use server";
+import { cookies } from "next/headers";
+
+export default async function customFetchAPI<DataT = unknown, ErrorT = unknown>(
+  path: string,
+  options: {
+    method?: string;
+    body?: Record<string, any>;
+    search?: Record<string, string>;
+  } = {}
+) {
+  const Cookies = cookies();
+
+  const authentication = Cookies.get("LMMs_TDM_Authentication_Token")?.value;
+  const headers: HeadersInit = new Headers();
+  if (authentication) {
+    headers.set("Authentication", authentication);
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_SERVER_BASE_URL || "";
+  const { body, method, search } = options;
+  const searchParams = search ? new URLSearchParams(search).toString() : "";
+
+  const response = await fetch(`${baseUrl}/${path}?${searchParams}`, {
+    headers,
+    method,
+    body: body && JSON.stringify(body),
+  });
+
+  const responseBody = await response.json();
+
+  response.headers.getSetCookie().forEach((cookie) => {
+    const [key, value] = cookie.split("=");
+    Cookies.set(key, value);
+  });
+
+  return {
+    body: responseBody as DataT,
+    status: response.status,
+    success: response.status > 199 && response.status < 300,
+  };
+}

--- a/src/lib/fetchErrorsHandler.ts
+++ b/src/lib/fetchErrorsHandler.ts
@@ -1,0 +1,24 @@
+import FetchError from "./FetchError";
+
+export default function fetchErrorsHandler<ErrorT>(
+  responseBody: any,
+  status: number
+) {
+  let errorMessage = "Unexpected error";
+
+  if (status === 403) {
+    errorMessage = "Validation Error";
+  } else if (status === 401) {
+    errorMessage = "Authorization Error";
+  } else if (status < 500) {
+    errorMessage = "Bad Request";
+  } else {
+    errorMessage = "Internal Server Error";
+  }
+
+  const error = new FetchError<ErrorT>(responseBody.message || errorMessage, {
+    status,
+    error: responseBody?.error,
+  });
+  return error;
+}

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -12,17 +12,3 @@ type ErrorDetails<ErrorT> = {
   status?: number;
   error?: ErrorT | undefined;
 };
-
-class FetchError<ErrorT = unknown> extends Error {
-  status: number | undefined;
-  error: ErrorT | undefined;
-  constructor(message: string, details?: ErrorDetails<ErrorT> & ErrorOptions) {
-    super(message, { cause: details?.cause });
-    this.status = details?.status;
-    this.error = details?.error;
-    if (details?.status) {
-      this.name =
-        details.status < 500 ? "Bad Request" : "Internal Server Error";
-    }
-  }
-}


### PR DESCRIPTION
Separate the section that handles preparing the headers, url path and search params of the request,  And sends 
the request using the native fetch function, to a server action function called `customFetchAPI` in 
`src/lib/customFetchAPI.ts` file.

And convert `fetchAPI` function from a server action to a function works normally in the client, calls `customFetchAPI` 
function and handles returning the response and throwing an error if the request failed.