### PR TITLE
Create dataset page context

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import ReactQueryProvider from "@/components/ReactQueryProvider";
 import Header from "@/components/header/Header";
 import { PropsWithChildren } from "react";
 import { Toaster } from "@/components/ui/sonner";
+import DatasetPageContext from "@/contexts/DatasetPageContext";
 
 const fontSans = Inter({
   subsets: ["latin"],
@@ -29,11 +30,13 @@ export default function RootLayout({ children }: PropsWithChildren) {
       >
         <ReactQueryProvider>
           <TooltipProvider>
-            <Header />
-            <main className="flex h-full flex-1">
-              {children}
-            </main>
-            <Toaster />
+            <DatasetPageContext>
+              <Header />
+              <main className="flex h-full flex-1">
+                {children}
+              </main>
+              <Toaster />
+            </DatasetPageContext>
           </TooltipProvider>
         </ReactQueryProvider>
       </body>

--- a/src/contexts/DatasetPageContext.tsx
+++ b/src/contexts/DatasetPageContext.tsx
@@ -1,0 +1,49 @@
+"use client"
+import { createContext, Dispatch, PropsWithChildren, SetStateAction, useState } from "react";
+
+type DatasetPageContextType = {
+    dataset: Dataset | null;
+    selectedInstruction: Instruction | null;
+    setDataset: Dispatch<SetStateAction<Dataset | null>>;
+    setSelectedInstruction: Dispatch<SetStateAction<Instruction | null>>
+    addInstructionMode: boolean;
+    setAddInstructionMode: Dispatch<SetStateAction<boolean>>;
+    editInstructionMode: boolean;
+    setEditInstructionMode: Dispatch<SetStateAction<boolean>>;
+}
+
+export const datasetPageContext = createContext<DatasetPageContextType>({
+    dataset: null,
+    selectedInstruction: null,
+    setDataset() { },
+    setSelectedInstruction() { },
+    editInstructionMode: false,
+    setEditInstructionMode() { },
+    addInstructionMode: false,
+    setAddInstructionMode() { },
+});
+
+export default function DatasetPageContext({ children }: PropsWithChildren) {
+
+    const [dataset, setDataset] = useState<Dataset | null>(null)
+    const [selectedInstruction, setSelectedInstruction] = useState<Instruction | null>(null)
+    const [addInstructionMode, setAddInstructionMode] = useState(false);
+    const [editInstructionMode, setEditInstructionMode] = useState(false);
+
+    return (
+        <datasetPageContext.Provider
+            value={{
+                dataset,
+                selectedInstruction,
+                setDataset,
+                setSelectedInstruction,
+                addInstructionMode,
+                setAddInstructionMode,
+                setEditInstructionMode,
+                editInstructionMode
+            }}
+        >
+            {children}
+        </datasetPageContext.Provider>
+    )
+};

--- a/src/hook/datasets/useDatasetPageContext.ts
+++ b/src/hook/datasets/useDatasetPageContext.ts
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import { datasetPageContext } from "@/contexts/DatasetPageContext";
+
+export default function useDatasetPageContext() {
+  return useContext(datasetPageContext);
+}


### PR DESCRIPTION
Create `DatasetPageContext` component which wraps
its children with context provider to share its states to all child components,
And then wrap the root layout with DatasetPageContext component to share 
its state with all components in the app.

The states of `DatasetPageContext` component are:

- `dataset` state which is the state of the opend dataset
in dataset page.

- `selectedInstruction` state for the selected instruction
for editing or deleting in dataset page.

- `addInstructionMode` state to specify whither the form
of adding instructions is opened or not.

- `editInstructionMode` state to specify whither the form
of editing instructions is opened or not.