### PR TITLE
Prevent an external library from overriding the padding & margin styles of the body element

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,9 +24,10 @@ export default function RootLayout({ children }: PropsWithChildren) {
     <html lang="en">
       <body
         className={cn(
-          "min-h-screen bg-background font-sans antialiased flex flex-col gap-2 container px-2",
+          "min-h-screen bg-background font-sans antialiased flex flex-col gap-2 container !px-2",
           fontSans.variable
         )}
+        style={{ marginLeft: "auto !important", marginRight: "auto !important" }}
       >
         <ReactQueryProvider>
           <TooltipProvider>


### PR DESCRIPTION
Add `marginLeft: "auto !important", marginRight: "auto !important"` inline styles to the body 
element and prefix its "px-2" class with "!" to prevent the dialog component from overriding its 
padding and marging styles when dialog component been open.