### PR TITLE
Create `useDatasetsGridState` hook

### DIFF
--- a/src/hook/datasets/useDatasetsGridState.ts
+++ b/src/hook/datasets/useDatasetsGridState.ts
@@ -1,0 +1,48 @@
+import { useQueryClient } from "@tanstack/react-query";
+
+export default function useDatasetsGridState() {
+  const QueryClient = useQueryClient();
+
+  function addToDatasetsGrid(dataset: Dataset) {
+    QueryClient.setQueryData<Dataset[]>(["datasets"], (preData) => {
+      if (preData) {
+        return [dataset, ...preData];
+      }
+    });
+  }
+
+  function deleteFromDatasetsGrid(datasetId: Dataset["_id"]) {
+    QueryClient.setQueryData<Dataset[]>(["datasets"], (preData) => {
+      if (preData) {
+        return preData.filter((dataset) => dataset._id !== datasetId);
+      }
+    });
+  }
+
+  function updateInDatasetsGrid(
+    updatedData:
+      | Dataset
+      | (() => { updatefn: (pre: Dataset) => Dataset; id: Dataset["_id"] })
+  ) {
+    QueryClient.setQueryData<Dataset[]>(["datasets"], (preData) => {
+      if (preData) {
+        if (typeof updatedData === "function") {
+          const { id, updatefn } = updatedData();
+          return preData.map((dataset) =>
+            dataset._id === id ? updatefn(dataset) : dataset
+          );
+        } else {
+          return preData.map((dataset) =>
+            dataset._id === updatedData._id ? updatedData : dataset
+          );
+        }
+      }
+    });
+  }
+
+  return {
+    addToDatasetsGrid,
+    updateInDatasetsGrid,
+    deleteFromDatasetsGrid,
+  };
+}


### PR DESCRIPTION
Create `useDatasetsGridState` hook to provide utils functions for updating the datasets of datasets grid in datasets page.

it provides `updateInDatasetsGrid`, `addToDatasetsGrid` and `deleteFromDatasetsGrid` methods to update the state 
of datasets grid in datasets page.