### PR TITLE
Create forms validation rules schemas for the datasets and the instructions

### DIFF
--- a/src/validation/datasetFormSchemaRules.ts
+++ b/src/validation/datasetFormSchemaRules.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+const MAX_DATASET_NAME_LENGHT = 100;
+const MAX_DATASET_DESCRIPTION_LENGHT = 150;
+
+const datasetFormSchemaRules = {
+  name: z
+    .string()
+    .min(2, {
+      message: "Dataset name must be at least 2 characters.",
+    })
+    .max(MAX_DATASET_NAME_LENGHT, {
+      message: `Dataset name must not be over ${MAX_DATASET_NAME_LENGHT} characters.`,
+    }),
+  description: z
+    .string()
+    .min(2, {
+      message: "Dataset description must be at least 2 characters.",
+    })
+    .max(MAX_DATASET_DESCRIPTION_LENGHT, {
+      message: `Dataset description must not be over ${MAX_DATASET_DESCRIPTION_LENGHT} characters.`,
+    }),
+};
+
+export default datasetFormSchemaRules;

--- a/src/validation/instructionFormSchemaRules.ts
+++ b/src/validation/instructionFormSchemaRules.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+const MAX_INSTRUCTION_SYS_MSG_LENGHT = 500;
+const MAX_INSTRUCTION_QUESTION_LENGHT = 5000;
+const MAX_INSTRUCTION_ANSWER_LENGHT = 5000;
+
+const MIN_INSTRUCTION_SYS_MSG_LENGHT = 6;
+const MIN_INSTRUCTION_QUESTION_LENGHT = 6;
+const MIN_INSTRUCTION_ANSWER_LENGHT = 6;
+
+const DATASET_ID_LENGHT = 24;
+
+export const instructionFormSchemaRules = {
+  systemMessage: z
+    .string()
+    .refine(
+      (input) => !input || input.length >= MIN_INSTRUCTION_SYS_MSG_LENGHT,
+      {
+        message: `System Message must be at least ${MIN_INSTRUCTION_SYS_MSG_LENGHT} characters.`,
+      }
+    )
+    .refine(
+      (input) => !input || input.length <= MAX_INSTRUCTION_SYS_MSG_LENGHT,
+      {
+        message: `System Message must not be over ${MAX_INSTRUCTION_SYS_MSG_LENGHT} characters.`,
+      }
+    )
+    .optional(),
+  question: z
+    .string()
+    .min(MIN_INSTRUCTION_QUESTION_LENGHT, {
+      message: `The question must be at least ${MIN_INSTRUCTION_QUESTION_LENGHT} characters.`,
+    })
+    .max(MAX_INSTRUCTION_QUESTION_LENGHT, {
+      message: `The question must not be over ${MAX_INSTRUCTION_QUESTION_LENGHT} characters.`,
+    }),
+  answer: z
+    .string()
+    .min(MIN_INSTRUCTION_ANSWER_LENGHT, {
+      message: `The answer must be at least ${MIN_INSTRUCTION_ANSWER_LENGHT} characters.`,
+    })
+    .max(MAX_INSTRUCTION_ANSWER_LENGHT, {
+      message: `The answer must not be over ${MAX_INSTRUCTION_ANSWER_LENGHT} characters.`,
+    }),
+  datasetId: z
+    .string()
+    .min(DATASET_ID_LENGHT, {
+      message: `The dataset id must consist of ${DATASET_ID_LENGHT} characters.`,
+    })
+    .max(DATASET_ID_LENGHT, {
+      message: `The dataset id must consist of ${DATASET_ID_LENGHT} characters.`,
+    }),
+};
+
+export default instructionFormSchemaRules;


### PR DESCRIPTION
- Create `src/validation/datasetFormSchemaRules.ts` file
and create inside it the datasets form validation schema.

- Create `src/validation/instructionFormSchemaRules.ts` file
and create inside it the form validation schema or the
instructions of datasets.