### PR TITLE
Create the form and the logics hook of creating new datasets

### DIFF
--- a/src/components/datasets/CreateDatasetForm.tsx
+++ b/src/components/datasets/CreateDatasetForm.tsx
@@ -1,0 +1,24 @@
+"use client"
+import useCreateDatasetForm from "@/hook/datasets/useCreateDatasetForm"
+import DatasetForm from "./DatasetForm"
+
+export default function CreateDatasetForm() {
+
+    const {
+        form,
+        onSubmit,
+        isPending,
+        error
+    } = useCreateDatasetForm();
+
+    return (
+        <DatasetForm
+            form={form}
+            onSubmit={onSubmit}
+            formTitle="Create Dataset Form"
+            formDescription="Fill out this form to create your dataset"
+            isLoading={isPending}
+            error={error}
+        />
+    )
+}

--- a/src/components/datasets/DatasetForm.tsx
+++ b/src/components/datasets/DatasetForm.tsx
@@ -1,0 +1,79 @@
+import { Input } from "../ui/input"
+import { Textarea } from "../ui/textarea"
+import {
+    Form,
+    FormControl,
+    FormDescription,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage
+} from "../ui/form"
+import { Button } from "../ui/button"
+import { DialogTitle } from "../ui/dialog"
+import FetchError from "@/lib/FetchError"
+
+type DatasetFormProps = {
+    form: any,
+    onSubmit: (newDataset: any) => Promise<void>
+    formTitle: string;
+    formDescription: string;
+    isLoading: boolean;
+    error: FetchError | null;
+}
+
+export default function DatasetForm({ form, onSubmit, formTitle, formDescription }: DatasetFormProps) {
+    return (
+        <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                <div>
+                    <DialogTitle className="text-2xl font-bold">
+                        {formTitle}
+                    </DialogTitle>
+                    <p className="text-muted-foreground">
+                        {formDescription}
+                    </p>
+                </div>
+                <div className="grid gap-3">
+                    <div className="grid gap-3">
+                        <FormField
+                            control={form.control}
+                            name="name"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Name</FormLabel>
+                                    <FormControl>
+                                        <Input {...field} />
+                                    </FormControl>
+                                    <FormDescription>
+                                        This is the name of your dataset.
+                                    </FormDescription>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                    </div>
+                    <div className="grid gap-3">
+                        <FormField
+                            control={form.control}
+                            name="description"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Description</FormLabel>
+                                    <FormControl>
+                                        <Textarea {...field} />
+                                    </FormControl>
+                                    <FormDescription>
+                                        This is the description of your dataset
+                                    </FormDescription>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                    </div>
+                </div>
+                <Button type="submit">Submit</Button>
+            </form>
+        </Form>
+    )
+}

--- a/src/hook/datasets/useCreateDatasetForm.ts
+++ b/src/hook/datasets/useCreateDatasetForm.ts
@@ -1,0 +1,72 @@
+"use client";
+import fetchAPI from "@/lib/fetchAPI";
+import datasetFormSchemaRules from "@/validation/datasetFormSchemaRules";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import useSonnerToast from "../useSonnerToast";
+import { useMutation } from "@tanstack/react-query";
+import useDatasetsStatesManagement from "./useDatasetsStatesManagement";
+import FetchError from "@/lib/FetchError";
+
+const datasetFormSchema = z.object(datasetFormSchemaRules);
+
+type CreaetDatasetInput = z.infer<typeof datasetFormSchema>;
+
+type ResponseType = {
+  message?: string;
+  data: Dataset;
+};
+
+const defaultValues = {
+  name: "",
+  description: "",
+};
+
+export default function useCreateDatasetForm() {
+  const form = useForm<CreaetDatasetInput>({
+    resolver: zodResolver(datasetFormSchema),
+    defaultValues,
+  });
+
+  const toast = useSonnerToast();
+
+  const { addNewDatasetState } = useDatasetsStatesManagement();
+
+  const { mutateAsync, isPending, isSuccess, error } = useMutation<
+    ResponseType,
+    FetchError,
+    CreaetDatasetInput
+  >({
+    mutationKey: ["create-dataset"],
+    onSuccess(res) {
+      addNewDatasetState(res.data);
+      toast({
+        title: "The Dataset has been created successfully",
+        description: res.message,
+        variant: "success",
+      });
+      form.reset(defaultValues);
+      form.clearErrors();
+    },
+    async mutationFn(newDataset: CreaetDatasetInput) {
+      const { body } = await fetchAPI<ResponseType>("datasets", {
+        method: "POST",
+        body: newDataset,
+      });
+      return body;
+    },
+  });
+
+  async function onSubmit(newDataset: CreaetDatasetInput) {
+    await mutateAsync(newDataset);
+  }
+
+  return {
+    onSubmit,
+    isPending,
+    isSuccess,
+    error,
+    form,
+  };
+}


### PR DESCRIPTION
- Create `useCreateDatasetForm` hook for handling validating datasets inputs, Creating new datasets mutations
queries, Updating datasets states in the application after adding a new dataset, And firing feedback message as
toasts using `useSonnerToast` hook.

- Create `DatasetForm` component which is a reusable component used for getting a ready dataset form to
use with `name` and `description` inputs. This component is created for reusing it to build "create
new dataset" and "update dataset" forms.

- Create `CreateDatasetForm` component which is the form of creating new datasets, It uses 
`useCreateDatasetForm` to to handle all logics around of creating new datasets and uses `DatasetForm` 
to build the actual form element with its inputs.