### PR TITLE
Create a wrapper for dialog component

### DIFF
--- a/src/components/DialogWrapper.tsx
+++ b/src/components/DialogWrapper.tsx
@@ -1,0 +1,24 @@
+import {
+    Dialog,
+    DialogContent,
+    DialogTrigger,
+} from "@/components/ui/dialog"
+import { ReactNode } from "react"
+
+type DialogWrapperProps = {
+    content: ReactNode;
+    trigger: ReactNode;
+}
+
+export default function DialogWrapper({ content, trigger }: DialogWrapperProps) {
+    return (
+        <Dialog>
+            <DialogTrigger asChild>
+                {trigger}
+            </DialogTrigger>
+            <DialogContent>
+                {content}
+            </DialogContent>
+        </Dialog>
+    )
+}


### PR DESCRIPTION
Create `DialogWrapper` component which is just a wrapper for the dialog component of `shadcn/ui`
library to make using the dialog component easier.