### PR TITLE
Create datasets instructions context

### DIFF
--- a/src/contexts/DatasetInstructionsContext.tsx
+++ b/src/contexts/DatasetInstructionsContext.tsx
@@ -1,0 +1,56 @@
+"use client"
+import useDatasetInstructions from "@/hook/instructions/useDatasetInstructions";
+import FetchError from "@/lib/FetchError";
+import { createContext, Dispatch, PropsWithChildren, SetStateAction } from "react";
+
+type DatasetPageContextType = {
+    data?: DatasetInstructionsPage,
+    nextPage: () => void,
+    previousPage: () => void,
+    goToPage: (pageNumber: number) => void,
+    isFetching: boolean,
+    error: FetchError | null,
+    paginationModel: PaginationModel,
+    setPaginationModel: Dispatch<SetStateAction<PaginationModel>>
+}
+
+export const datasetInstructionsContext = createContext<DatasetPageContextType>({
+    nextPage() { },
+    previousPage() { },
+    goToPage() { },
+    paginationModel: { page: 1, pageSize: 1 },
+    isFetching: false,
+    error: null,
+    setPaginationModel() { }
+});
+
+export default function DatasetInstructionsContext({ children }: PropsWithChildren) {
+
+    const {
+        data: datasetInstructions,
+        nextPage,
+        previousPage,
+        goToPage,
+        isFetching: instructionsLoading,
+        error: instructionsError,
+        paginationModel,
+        setPaginationModel
+    } = useDatasetInstructions();
+
+    return (
+        <datasetInstructionsContext.Provider
+            value={{
+                data: datasetInstructions,
+                nextPage,
+                previousPage,
+                goToPage,
+                isFetching: instructionsLoading,
+                error: instructionsError,
+                paginationModel,
+                setPaginationModel
+            }}
+        >
+            {children}
+        </datasetInstructionsContext.Provider>
+    )
+};

--- a/src/hook/instructions/useDatasetInstructions.ts
+++ b/src/hook/instructions/useDatasetInstructions.ts
@@ -1,0 +1,101 @@
+import fetchAPI from "@/lib/fetchAPI";
+import FetchError from "@/lib/FetchError";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import useDatasetPageContext from "../datasets/useDatasetPageContext";
+
+export type DatasetInstructionsQueryResponse = {
+  data: DatasetInstructionsPage;
+};
+
+export default function useDatasetInstructions() {
+  const { datasetId } = useParams();
+  const initialPaginationModel = { page: 1, pageSize: 4 };
+  const [paginationModel, setPaginationModel] = useState<PaginationModel>(
+    initialPaginationModel
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<FetchError>();
+  const [isFirstRender, setIsFirstRender] = useState(true);
+
+  const { setSelectedInstruction, setDataset } = useDatasetPageContext();
+
+  const QueryClient = useQueryClient();
+  const queryKey = ["dataset-instructions", datasetId];
+
+  const {
+    data,
+    error: queryError,
+    isFetching,
+  } = useQuery<DatasetInstructionsQueryResponse["data"], FetchError>({
+    queryKey,
+    queryFn: () => fetchPage(paginationModel),
+  });
+
+  async function fetchPage(paginationModel: PaginationModel) {
+    const { body } = await fetchAPI<
+      Omit<DatasetInstructionsQueryResponse, "page">
+    >("instructions", {
+      search: {
+        page: String(paginationModel.page),
+        pageSize: String(paginationModel.pageSize),
+        datasetId: datasetId as string,
+      },
+    });
+    return body.data;
+  }
+
+  async function stepToPage(steps: number, fromStart: boolean = false) {
+    setIsLoading(true);
+    const targetPage = {
+      pageSize: paginationModel.pageSize,
+      page: fromStart ? steps : paginationModel.page + steps,
+    };
+    setPaginationModel(targetPage);
+    try {
+      const pageData = await fetchPage(targetPage);
+      QueryClient.setQueryData(queryKey, pageData);
+      setIsLoading(false);
+    } catch (error) {
+      setError(error as FetchError);
+    }
+  }
+
+  function nextPage() {
+    stepToPage(1);
+  }
+
+  function previousPage() {
+    stepToPage(-1);
+  }
+
+  function goToPage(pageNumber: number) {
+    stepToPage(pageNumber, true);
+  }
+
+  useEffect(() => {
+    return () => {
+      if (!isFirstRender) {
+        QueryClient.resetQueries({
+          queryKey: ["dataset-instructions", datasetId],
+        });
+        setDataset(null);
+        setSelectedInstruction(null);
+      }
+    };
+  }, [isFirstRender]);
+
+  useEffect(() => setIsFirstRender(false), []);
+
+  return {
+    data: data,
+    isFetching: isLoading || isFetching,
+    error: error || queryError,
+    paginationModel,
+    setPaginationModel,
+    nextPage,
+    previousPage,
+    goToPage,
+  };
+}

--- a/src/hook/instructions/useDatasetInstructionsContext.ts
+++ b/src/hook/instructions/useDatasetInstructionsContext.ts
@@ -1,0 +1,6 @@
+import { datasetInstructionsContext } from "@/contexts/DatasetInstructionsContext";
+import { useContext } from "react";
+
+export default function useDatasetInstructionsContext() {
+  return useContext(datasetInstructionsContext);
+}

--- a/src/hook/instructions/useDatasetInstructionsState.ts
+++ b/src/hook/instructions/useDatasetInstructionsState.ts
@@ -1,0 +1,81 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { DatasetInstructionsQueryResponse } from "./useDatasetInstructions";
+import useDatasetPage from "../datasets/useDatasetPage";
+
+type StateType = DatasetInstructionsQueryResponse["data"];
+
+export default function useDatasetInstructionsState() {
+  const QueryClient = useQueryClient();
+
+  const { paginationModel, previousPage, goToPage } = useDatasetPage();
+
+  function addInstructionsToDataset(
+    datasetId: Dataset["_id"],
+    newInstruction: Instruction
+  ) {
+    QueryClient.setQueryData<StateType>(
+      ["dataset-instructions", datasetId],
+      (state) => {
+        if (state) {
+          if (state.instructions.length < paginationModel.pageSize) {
+            state.instructions = [...state.instructions, newInstruction];
+          }
+        }
+        return state;
+      }
+    );
+  }
+
+  function updateInstructionOfDataset(
+    datasetId: Dataset["_id"],
+    instructionId: Instruction["_id"],
+    updatedInstruction: Instruction | ((pre?: Instruction) => Instruction)
+  ) {
+    QueryClient.setQueryData<StateType>(
+      ["dataset-instructions", datasetId],
+      (state) => {
+        if (state) {
+          state.instructions = state.instructions.map((instruction) => {
+            if (instructionId === instruction._id) {
+              return typeof updatedInstruction === "function"
+                ? updatedInstruction(instruction)
+                : updatedInstruction;
+            }
+            return instruction;
+          });
+        }
+        return state;
+      }
+    );
+  }
+
+  function removeInstructionFromDataset(
+    datasetId: Dataset["_id"],
+    instructionId: Instruction["_id"]
+  ) {
+    QueryClient.setQueryData<StateType>(
+      ["dataset-instructions", datasetId],
+      (state) => {
+        if (state) {
+          state.instructions = state.instructions.filter(
+            (instruction) => instruction._id !== instructionId
+          );
+          if (!state.instructions.length) {
+            if (paginationModel.page === 1) {
+              goToPage(1);
+            } else {
+              previousPage();
+            }
+          }
+        }
+        return state;
+      }
+    );
+  }
+
+  return {
+    addInstructionsToDataset,
+    updateInstructionOfDataset,
+    removeInstructionFromDataset,
+  };
+}


### PR DESCRIPTION
- Create `useDatasetInstructions` hook which handles paginating and fetching a dataset instructions.

- Create `DatasetInstructionsContext` component to share the state of a dataset instructions using 
react context feature.

- Create `useDatasetInstructionsState` hook for handling updating the state of dataset Instructions.

- Create `useDatasetInstructionsContext` hook to provide a straightforward way to access dataset 
instructions context  state.