### PR TITLE
Fix trying to update data based on incorrect type error

### DIFF
--- a/src/hook/datasets/useDatasetsOverviewState.ts
+++ b/src/hook/datasets/useDatasetsOverviewState.ts
@@ -11,17 +11,14 @@ export default function useDatasetsOverviewState() {
 
     const isAddedLastMonth = lastMonthDate < new Date(createdAt).getTime();
 
-    QueryClient.setQueryData<{ data: DatasetsOverview }>(
+    QueryClient.setQueryData<DatasetsOverview>(
       ["datasets-overview"],
       (preData) => {
         if (preData) {
           return {
-            data: {
-              totalDatasets: preData.data.totalDatasets + amount,
-              addedDatasetsLastMonth:
-                preData.data.addedDatasetsLastMonth +
-                (isAddedLastMonth ? amount : 0),
-            },
+            totalDatasets: preData.totalDatasets + amount,
+            addedDatasetsLastMonth:
+              preData.addedDatasetsLastMonth + (isAddedLastMonth ? amount : 0),
           };
         }
       }


### PR DESCRIPTION
Set the correct data type for the state of datasets overview in `useDatasetsOverviewState` and rewrite 
updating logic based of the correct data type or shape.