### PR TITLE
Create dataset instructions section and add it to dataset page

### DIFF
--- a/src/app/datasets/[datasetId]/page.tsx
+++ b/src/app/datasets/[datasetId]/page.tsx
@@ -1,4 +1,5 @@
 import DatasetFullCard from "@/components/datasets/DatasetFullCard";
+import InstructionsSection from "@/components/instructions/InstructionsSection";
 import DatasetInstructionsContext from "@/contexts/DatasetInstructionsContext";
 
 export default function DatasetPage() {
@@ -6,6 +7,7 @@ export default function DatasetPage() {
         <DatasetInstructionsContext>
             <div className="flex w-full flex-col gap-2">
                 <DatasetFullCard />
+                <InstructionsSection />
             </div>
         </DatasetInstructionsContext>
     )

--- a/src/components/instructions/AddInstructionsForm.tsx
+++ b/src/components/instructions/AddInstructionsForm.tsx
@@ -1,0 +1,106 @@
+"use client"
+import { Textarea } from "../ui/textarea"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from "../ui/form"
+import { Button } from "../ui/button"
+import useAddInstructionForm from "@/hook/instructions/useAddInstructionForm"
+import { MessageCircleCodeIcon, MessageCircleQuestionIcon, MessageCircleReplyIcon } from "lucide-react"
+import { Card, CardTitle } from "../ui/card"
+
+type AddInstructionsFormProps = {
+  dataset: Dataset,
+}
+
+export default function AddInstructionsForm(props: AddInstructionsFormProps) {
+
+  const { form, onSubmit, isPending } = useAddInstructionForm(props);
+
+  return (
+    <Card className="p-3 rounded-md mt-2 space-y-3">
+      <CardTitle className="py-3">Add Instructions Form</CardTitle>
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="flex flex-col gap-4">
+          <div className="grid gap-3">
+            <div className="grid gap-3">
+              <FormField
+                control={form.control}
+                name="systemMessage"
+                render={({ field }) => (
+                  <FormItem>
+                    <div className="flex gap-2 items-center">
+                      <MessageCircleCodeIcon className="size-4 sm:size-5" />
+                      <FormLabel>System Message</FormLabel>
+                    </div>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        placeholder="Type the system message here..."
+                        className="bg-muted max-h-40 h-fit resize-y border-0 p-3 shadow-none focus-visible:ring-0"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className="grid gap-3">
+              <FormField
+                control={form.control}
+                name="question"
+                render={({ field }) => (
+                  <FormItem>
+                    <div className="flex gap-2 items-center">
+                      <MessageCircleQuestionIcon className="size-4 sm:size-5" />
+                      <FormLabel>Question</FormLabel>
+                    </div>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        placeholder="Type the question here..."
+                        className="bg-muted max-h-40 resize-y border-0 p-3 shadow-none focus-visible:ring-0"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className="grid gap-3">
+              <FormField
+                control={form.control}
+                name="answer"
+                render={({ field }) => (
+                  <FormItem>
+                    <div className="flex gap-2 items-center">
+                      <MessageCircleReplyIcon className="size-4 sm:size-5" />
+                      <FormLabel>Answer</FormLabel>
+                    </div>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        placeholder="Type the answer here..."
+                        className="bg-muted max-h-80 resize-y border-0 p-3 shadow-none focus-visible:ring-0"
+                        rows={7}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </div>
+          <Button size="sm" type="submit" className="self-end">Add</Button>
+        </form>
+      </Form>
+    </Card>
+  )
+}
+

--- a/src/components/instructions/DeleteInstructionButton.tsx
+++ b/src/components/instructions/DeleteInstructionButton.tsx
@@ -1,0 +1,33 @@
+import { TrashIcon } from 'lucide-react'
+import ActionWithAlert from '../ActionWithAlert'
+import { Button } from '../ui/button'
+import useDeleteInstruction from '@/hook/instructions/useDeleteInstruction'
+
+export type DeleteInstructionButtonProps = {
+    datasetId: Dataset["_id"],
+    instructionId: Instruction["_id"]
+}
+
+export default function DeleteInstructionButton(props: DeleteInstructionButtonProps) {
+
+    const { deleteTheInstruction } = useDeleteInstruction(props)
+
+    return (
+        <ActionWithAlert
+            alertTitle='Deleting an instruction'
+            alertDescription='Are you sure you want to delete this instruction?'
+            onAgree={() => {
+                deleteTheInstruction();
+            }}
+            trigger={
+                <Button
+                    size="icon"
+                    variant="destructive"
+                    className="size-8"
+                >
+                    <TrashIcon size={17} />
+                </Button>
+            }
+        />
+    )
+}

--- a/src/components/instructions/InstructionFullCard.tsx
+++ b/src/components/instructions/InstructionFullCard.tsx
@@ -1,0 +1,89 @@
+"use client"
+import { Separator } from "@/components/ui/separator"
+import {
+  EditIcon,
+  MessageCircleCodeIcon,
+  MessageCircleQuestionIcon,
+  MessageCircleReplyIcon,
+} from "lucide-react"
+import { Button } from "../ui/button"
+import { cn } from "@/utils/tw-cn"
+import timeAgo from "@/utils/timeAgo"
+import UpdateInstructionForm from "./UpdateInstructionsForm"
+import useDatasetPage from "@/hook/datasets/useDatasetPage"
+import DeleteInstructionButton from "./DeleteInstructionButton"
+
+export default function InstructionFullCard() {
+
+  const {
+    dataset,
+    selectedInstruction,
+    editInstructionMode,
+    setEditInstructionMode
+  } = useDatasetPage();
+
+  if (selectedInstruction && dataset) {
+    if (editInstructionMode) {
+      return (
+        <UpdateInstructionForm
+          selectedInstruction={selectedInstruction}
+          dataset={dataset}
+          closeEditMode={() => setEditInstructionMode(false)}
+        />
+      )
+    } else {
+      return (
+        <div className="flex flex-1 flex-col h-[500px] overflow-auto pe-1">
+          <div className="flex items-center p-3 px-4 gap-3">
+            <Button size="icon" className="size-8">
+              <EditIcon size={17} onClick={() => setEditInstructionMode(true)} />
+            </Button>
+            <DeleteInstructionButton
+              datasetId={dataset._id}
+              instructionId={selectedInstruction._id}
+            />
+            <div className="ml-auto text-end text-sm text-muted-foreground">
+              <p>Created: {timeAgo(selectedInstruction.createdAt)}</p>
+              <p>Last modified: {timeAgo(selectedInstruction.updatedAt)}</p>
+            </div>
+          </div>
+          <Separator />
+          <div className="whitespace-pre-wrap p-4 text-sm">
+            <p className={
+              cn(
+                "font-semibold text-sm flex gap-1 text-muted-foreground",
+                selectedInstruction.systemMessage ? "" : "line-through"
+              )
+            }>
+              <MessageCircleCodeIcon className="size-4 sm:size-5" />
+              {
+                selectedInstruction.systemMessage ?
+                  selectedInstruction.systemMessage : "No System Message"
+              }
+            </p>
+          </div>
+          <Separator />
+          <div className="whitespace-pre-wrap p-4 text-sm">
+            <p className="font-medium flex gap-1">
+              <MessageCircleQuestionIcon className="size-4 sm:size-5" />
+              {selectedInstruction.question}
+            </p>
+          </div>
+          <Separator />
+          <div className="whitespace-pre-wrap p-4 text-sm">
+            <p className="font-medium flex gap-1">
+              <MessageCircleReplyIcon className="size-4 sm:size-5" />
+              {selectedInstruction.answer}
+            </p>
+          </div>
+        </div>
+      )
+    }
+  } else {
+    return (
+      <div className="p-8 text-center text-muted-foreground">
+        No selected instruction
+      </div>
+    )
+  }
+}

--- a/src/components/instructions/InstructionsList.tsx
+++ b/src/components/instructions/InstructionsList.tsx
@@ -1,0 +1,52 @@
+"use client"
+import InstructionsListCard from "./InstructionsListCard"
+import InstructionsListLoading from "./InstructionsListLoading"
+import useDatasetPage from "@/hook/datasets/useDatasetPage"
+import InstructionsPaginationController from "./InstructionsPaginationController"
+import NoInstructionsInList from "./NoInstructionsInList"
+import InstructionsListError from "./InstructionsListError"
+
+export default function InstructionsList() {
+
+  const {
+    datasetLoading,
+    datasetError,
+    datasetInstructions,
+    instructionsLoading,
+    instructionsError,
+    paginationModel,
+    goToPage
+  } = useDatasetPage()
+
+  const loading = instructionsLoading || datasetLoading;
+  const error = datasetError || instructionsError;
+
+  return (
+    <>
+      {
+        <div className="h-[500px] pe-1 mt-2 overflow-auto">
+          {
+            loading ? <InstructionsListLoading />
+              : error ? (
+                <InstructionsListError
+                  error={instructionsError}
+                  refetch={() => goToPage(paginationModel.page)}
+                  page={paginationModel.page}
+                />
+              ) :
+                datasetInstructions?.instructions.length ?
+                  <div className="flex flex-col gap-2">
+                    {datasetInstructions?.instructions.map((instruction) => (
+                      <InstructionsListCard key={instruction._id} instruction={instruction} />
+                    ))}
+                  </div>
+                  : <NoInstructionsInList />
+          }
+        </div>
+      }
+      <div className="p-3">
+        <InstructionsPaginationController />
+      </div>
+    </>
+  )
+}

--- a/src/components/instructions/InstructionsListCard.tsx
+++ b/src/components/instructions/InstructionsListCard.tsx
@@ -1,0 +1,53 @@
+"use client"
+import { MessageCircleCodeIcon, MessageCircleQuestionIcon, MessageCircleReplyIcon } from "lucide-react";
+import { Card } from "../ui/card";
+import timeAgo from "@/utils/timeAgo";
+import { cn } from "@/utils/tw-cn";
+import useDatasetPageContext from "@/hook/datasets/useDatasetPageContext";
+
+export default function InstructionsListCard({ instruction }: { instruction: Instruction }) {
+
+  const { selectedInstruction, setSelectedInstruction } = useDatasetPageContext()
+
+  return (
+    <Card
+      className={
+        cn(
+          "flex flex-col gap-2 p-3 transition-all hover:bg-accent",
+          selectedInstruction?._id === instruction._id && "bg-muted"
+        )
+      }
+      onClick={() => { setSelectedInstruction(instruction) }}
+    >
+      <div className="flex gap-1 text-muted-foreground">
+        <MessageCircleCodeIcon className="size-4 sm:size-5" />
+        <p className={
+          cn(
+            "font-semibold text-sm line-clamp-1",
+            instruction.systemMessage ? "" : "line-through"
+          )
+        }>
+          {
+            instruction.systemMessage ?
+              instruction.systemMessage.substring(0, 60) : "No System Message"
+          }
+        </p>
+        <span className="ml-auto text-xs sm:text-sm text-nowrap">
+          {timeAgo(instruction.createdAt)}
+        </span>
+      </div>
+      <div className="flex gap-1">
+        <MessageCircleQuestionIcon className="size-4 sm:size-5" />
+        <p className="text-xs sm:text-sm font-medium line-clamp-2">
+          {instruction.question}
+        </p>
+      </div>
+      <div className="flex gap-1">
+        <MessageCircleReplyIcon className="size-4 sm:size-5" />
+        <p className="text-xs sm:text-sm text-muted-foreground line-clamp-3">
+          {instruction.answer}
+        </p>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/instructions/InstructionsListError.tsx
+++ b/src/components/instructions/InstructionsListError.tsx
@@ -1,0 +1,27 @@
+import { WithErrorAndRefetch } from "@/lib/FetchError";
+import { OctagonXIcon, RotateCcwIcon } from "lucide-react";
+import { Button } from "../ui/button";
+
+type InstructionsListError = WithErrorAndRefetch<{
+  page: number
+}>
+
+export default function InstructionsListError({ error, refetch, page }: InstructionsListError) {
+  return (
+    <div className="flex flex-col gap-3 items-center justify-center col-span-full">
+      <OctagonXIcon size={55} className="text-destructive" />
+      <h2 className="text-2xl">Error !</h2>
+      <p className="text-muted-foreground">
+        An Error while fetching the page ({page}) of instructions: {error?.message}
+      </p>
+      <Button
+        size="sm"
+        onClick={() => refetch()}
+        className="gap-1"
+      >
+        <RotateCcwIcon size={17} />
+        Refetch
+      </Button>
+    </div>
+  )
+}

--- a/src/components/instructions/InstructionsListLoading.tsx
+++ b/src/components/instructions/InstructionsListLoading.tsx
@@ -1,0 +1,24 @@
+import { Card } from "../ui/card";
+import { Skeleton } from "../ui/skeleton";
+
+export default function InstructionsListLoading() {
+  return (
+    Array.from(new Array(5)).map((_n, i) => (
+      <Card className="flex flex-col gap-2 p-3" key={i}>
+        <div className="flex gap-1 items-center">
+          <Skeleton className="size-5 flex-shrink-0" />
+          <Skeleton className="w-full h-4 rounded-sm" />
+          <Skeleton className="w-28 h-4 rounded-sm" />
+        </div>
+        <div className="flex gap-1">
+          <Skeleton className="size-5 flex-shrink-0" />
+          <Skeleton className="w-full h-10" />
+        </div>
+        <div className="flex gap-1">
+          <Skeleton className="size-5 flex-shrink-0" />
+          <Skeleton className="w-full h-14" />
+        </div>
+      </Card>
+    ))
+  )
+}

--- a/src/components/instructions/InstructionsPaginationController.tsx
+++ b/src/components/instructions/InstructionsPaginationController.tsx
@@ -1,0 +1,48 @@
+"use client"
+import useDatasetPage from "@/hook/datasets/useDatasetPage"
+import { Button } from "../ui/button"
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react"
+
+export default function InstructionsPaginationController() {
+
+    const {
+        dataset,
+        datasetLoading,
+        datasetError,
+        instructionsLoading,
+        instructionsError,
+        nextPage,
+        previousPage,
+        paginationModel,
+    } = useDatasetPage()
+
+    const disable = !!(datasetLoading || datasetError || instructionsLoading || instructionsError)
+    const totalDatasets = dataset?.instructionsCount || 0
+    const totalPages = Math.ceil((totalDatasets / paginationModel.pageSize))
+
+    return (
+        <div className="flex items-center gap-1 flex-1 justify-end">
+            <Button
+                size="sm"
+                className="gap-1"
+                disabled={disable || paginationModel.page === 1}
+                onClick={() => previousPage()}
+            >
+                <ChevronLeftIcon className="h-4 w-4" />
+                Previous
+            </Button>
+            <span className="px-1">
+                {totalPages && paginationModel.page} of {totalPages}
+            </span>
+            <Button
+                size="sm"
+                className="gap-1"
+                disabled={disable || totalPages <= paginationModel.page}
+                onClick={() => nextPage()}
+            >
+                Next
+                <ChevronRightIcon className="h-4 w-4" />
+            </Button>
+        </div>
+    )
+}

--- a/src/components/instructions/InstructionsSection.tsx
+++ b/src/components/instructions/InstructionsSection.tsx
@@ -1,0 +1,38 @@
+"use client"
+import useDatasetPage from "@/hook/datasets/useDatasetPage";
+import AddInstructionsForm from "./AddInstructionsForm";
+import InstructionFullCard from "@/components/instructions/InstructionFullCard";
+import InstructionsList from "@/components/instructions/InstructionsList";
+import { Separator } from "@/components/ui/separator";
+import { NotepadTextIcon, ScrollTextIcon } from "lucide-react";
+
+export default function InstructionsSection() {
+
+    const { dataset, addInstructionMode } = useDatasetPage();
+
+    if (dataset) {
+        if (addInstructionMode) {
+            return <AddInstructionsForm dataset={dataset} />
+        }
+        return (
+            <div className="grid sm:grid-cols-2 gap-2 border p-2 pt-0 rounded-md">
+                <div>
+                    <h3 className="flex items-center gap-2 text-xl py-4">
+                        <ScrollTextIcon />
+                        Instructions
+                    </h3>
+                    <Separator />
+                    <InstructionsList />
+                </div>
+                <div>
+                    <h3 className="flex items-center gap-2 text-xl py-4">
+                        <NotepadTextIcon />
+                        Selected Instruction
+                    </h3>
+                    <Separator />
+                    <InstructionFullCard />
+                </div>
+            </div>
+        )
+    }
+}

--- a/src/components/instructions/NoInstructionsInList.tsx
+++ b/src/components/instructions/NoInstructionsInList.tsx
@@ -1,0 +1,27 @@
+"use client"
+import { PackageOpenIcon, PlusSquareIcon } from "lucide-react";
+import { Button } from "../ui/button";
+import useDatasetPageContext from "@/hook/datasets/useDatasetPageContext";
+
+export default function NoInstructionsInList() {
+
+  const { setAddInstructionMode } = useDatasetPageContext()
+
+  return (
+    <div className="flex flex-col gap-3 items-center justify-center col-span-full h-full">
+      <PackageOpenIcon size={55} />
+      <h2 className="text-2xl">No Instructions</h2>
+      <p className="text-muted-foreground">
+        There is no instructions in this dataset
+      </p>
+      <Button
+        size="sm"
+        onClick={() => setAddInstructionMode(true)}
+        className="gap-1"
+      >
+        <PlusSquareIcon size={17} />
+        Add Instructions
+      </Button>
+    </div>
+  )
+}

--- a/src/components/instructions/UpdateInstructionsForm.tsx
+++ b/src/components/instructions/UpdateInstructionsForm.tsx
@@ -1,0 +1,121 @@
+"use client"
+import { Textarea } from "../ui/textarea"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from "../ui/form"
+import { Button } from "../ui/button"
+import {
+  MessageCircleCodeIcon,
+  MessageCircleQuestionIcon,
+  MessageCircleReplyIcon
+} from "lucide-react"
+import { Card } from "../ui/card"
+import
+useUpdateInstructionForm,
+{ UseUpdateInstructionForm }
+  from "@/hook/instructions/useUpdateInstructionForm"
+
+export default function UpdateInstructionsForm(props: UseUpdateInstructionForm) {
+
+  const { form, onSubmit, isPending } = useUpdateInstructionForm(props);
+
+  return (
+    <Card className="p-3 rounded-md mt-2 space-y-3">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4">
+          <div className="grid gap-3">
+            <div className="grid gap-3">
+              <FormField
+                control={form.control}
+                name="systemMessage"
+                render={({ field }) => (
+                  <FormItem>
+                    <div className="flex gap-2 items-center">
+                      <MessageCircleCodeIcon className="size-4 sm:size-5" />
+                      <FormLabel>System Message</FormLabel>
+                    </div>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        placeholder="Type the system message here..."
+                        className="bg-muted max-h-40 h-fit resize-y border-0 p-3 shadow-none focus-visible:ring-0"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className="grid gap-3">
+              <FormField
+                control={form.control}
+                name="question"
+                render={({ field }) => (
+                  <FormItem>
+                    <div className="flex gap-2 items-center">
+                      <MessageCircleQuestionIcon className="size-4 sm:size-5" />
+                      <FormLabel>Question</FormLabel>
+                    </div>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        placeholder="Type the system message here..."
+                        className="bg-muted max-h-40 resize-y border-0 p-3 shadow-none focus-visible:ring-0"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className="grid gap-3">
+              <FormField
+                control={form.control}
+                name="answer"
+                render={({ field }) => (
+                  <FormItem>
+                    <div className="flex gap-2 items-center">
+                      <MessageCircleReplyIcon className="size-4 sm:size-5" />
+                      <FormLabel>Answer</FormLabel>
+                    </div>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        placeholder="Type the system message here..."
+                        className="bg-muted max-h-80 resize-y border-0 p-3 shadow-none focus-visible:ring-0"
+                        rows={7}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </div>
+          <div className="flex justify-end gap-3">
+            <Button
+              size="sm"
+              variant="outline"
+              className="self-end"
+              onClick={(e) => {
+                e.preventDefault()
+                props.closeEditMode()
+              }}
+            >
+              Cancel
+            </Button>
+            <Button size="sm" type="submit" className="self-end">
+              Update
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </Card>
+  )
+}
+

--- a/src/hook/instructions/useAddInstructionForm.ts
+++ b/src/hook/instructions/useAddInstructionForm.ts
@@ -1,0 +1,86 @@
+import instructionFormSchemaRules from "@/validation/instructionFormSchemaRules";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import useSonnerToast from "../useSonnerToast";
+import fetchAPI from "@/lib/fetchAPI";
+import FetchError from "@/lib/FetchError";
+import useInstructionsStatesManagement from "./useInstructionsStatesManagement";
+
+type AddInstructionsInput = Omit<InstructionBase, "_id"> & {
+  datasetId: Dataset["_id"];
+};
+
+type MutationResponseType = {
+  data: Instruction;
+  message: string;
+};
+
+const instructionFormSchema = z.object(instructionFormSchemaRules);
+
+const defaultValues = {
+  systemMessage: "",
+  question: "",
+  answer: "",
+};
+
+type UseAddInstructionFormProps = {
+  dataset: Dataset;
+};
+
+export default function useAddInstructionForm({
+  dataset,
+}: UseAddInstructionFormProps) {
+  const form = useForm<AddInstructionsInput>({
+    resolver: zodResolver(instructionFormSchema),
+    defaultValues: {
+      ...defaultValues,
+      datasetId: dataset._id,
+    },
+  });
+  const { addNewInstructionState } = useInstructionsStatesManagement();
+  const toast = useSonnerToast();
+
+  const { mutateAsync, isPending, isSuccess, error } = useMutation<
+    MutationResponseType,
+    FetchError,
+    AddInstructionsInput
+  >({
+    mutationKey: ["add-instructions"],
+    onSuccess(res) {
+      form.reset({
+        ...defaultValues,
+        datasetId: dataset._id,
+      });
+      addNewInstructionState(dataset, res.data);
+      form.clearErrors();
+      toast({
+        title: "The instruction was added successfully",
+        variant: "success",
+      });
+    },
+    async mutationFn(instruction: AddInstructionsInput) {
+      const { body } = await fetchAPI<MutationResponseType>(`instructions`, {
+        method: "POST",
+        body: instruction,
+      });
+      return body;
+    },
+  });
+
+  async function onSubmit(instruction: AddInstructionsInput) {
+    if (!instruction.systemMessage) {
+      instruction.systemMessage = undefined;
+    }
+    mutateAsync(instruction);
+  }
+
+  return {
+    onSubmit,
+    form,
+    isPending,
+    isSuccess,
+    error,
+  };
+}

--- a/src/hook/instructions/useDeleteInstruction.ts
+++ b/src/hook/instructions/useDeleteInstruction.ts
@@ -1,0 +1,44 @@
+"use client";
+import fetchAPI from "@/lib/fetchAPI";
+import useSonnerToast from "../useSonnerToast";
+import { useMutation } from "@tanstack/react-query";
+import { DeleteInstructionButtonProps } from "@/components/instructions/DeleteInstructionButton";
+import useInstructionsStatesManagement from "./useInstructionsStatesManagement";
+
+export default function useDeleteInstruction({
+  datasetId,
+  instructionId,
+}: DeleteInstructionButtonProps) {
+  const { deleteInstructionState } = useInstructionsStatesManagement();
+
+  const toast = useSonnerToast();
+
+  const { mutateAsync, isPending, isSuccess, error } = useMutation({
+    mutationKey: ["delete-instructions"],
+    onSuccess(res) {
+      deleteInstructionState(datasetId, instructionId);
+      toast({
+        title: "The instruction has been deleted successfully",
+        variant: "success",
+      });
+    },
+    async mutationFn() {
+      const { body } = await fetchAPI(`instructions`, {
+        method: "DELETE",
+        search: { datasetId, instructionId },
+      });
+      return body;
+    },
+  });
+
+  async function deleteTheInstruction() {
+    await mutateAsync();
+  }
+
+  return {
+    deleteTheInstruction,
+    isPending,
+    isSuccess,
+    error,
+  };
+}

--- a/src/hook/instructions/useUpdateInstructionForm.ts
+++ b/src/hook/instructions/useUpdateInstructionForm.ts
@@ -1,0 +1,88 @@
+"use client";
+import instructionFormSchemaRules from "@/validation/instructionFormSchemaRules";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import useSonnerToast from "../useSonnerToast";
+import fetchAPI from "@/lib/fetchAPI";
+import useInstructionsStatesManagement from "./useInstructionsStatesManagement";
+import FetchError from "@/lib/FetchError";
+
+type UpdateInstructionsInput = Partial<Omit<InstructionBase, "_id">>;
+
+const instructionFormSchema = z.object({
+  systemMessage: instructionFormSchemaRules.systemMessage,
+  question: instructionFormSchemaRules.question.optional(),
+  answer: instructionFormSchemaRules.answer.optional(),
+});
+
+type MutationResponseType = {
+  data: Instruction;
+  message?: string;
+};
+
+export type UseUpdateInstructionForm = {
+  selectedInstruction: Instruction;
+  dataset: Dataset;
+  closeEditMode: () => void;
+};
+
+export default function UseUpdateInstructionForm({
+  selectedInstruction,
+  dataset,
+  closeEditMode,
+}: UseUpdateInstructionForm) {
+  const form = useForm<UpdateInstructionsInput>({
+    resolver: zodResolver(instructionFormSchema),
+    defaultValues: selectedInstruction,
+  });
+
+  const { updateInstructionState } = useInstructionsStatesManagement();
+
+  const toast = useSonnerToast();
+
+  const { mutateAsync, isPending, isSuccess, error } = useMutation<
+    MutationResponseType,
+    FetchError,
+    UpdateInstructionsInput
+  >({
+    mutationKey: ["update-instructions"],
+    onSuccess(res) {
+      updateInstructionState(dataset, res.data);
+      closeEditMode();
+      form.clearErrors();
+      toast({
+        title: "The instruction was updated successfully",
+        variant: "success",
+      });
+    },
+    async mutationFn(updatedInstruction: UpdateInstructionsInput) {
+      const { body } = await fetchAPI<MutationResponseType>(`instructions`, {
+        method: "PATCH",
+        search: {
+          datasetId: selectedInstruction.datasetId,
+          instructionId: selectedInstruction._id,
+        },
+        body: updatedInstruction,
+      });
+      return body;
+    },
+  });
+
+  async function onSubmit(instructionForm: UpdateInstructionsInput) {
+    if (Object.values(instructionForm).some((data) => !!data)) {
+      await mutateAsync(instructionForm);
+    } else {
+      //
+    }
+  }
+
+  return {
+    onSubmit,
+    form,
+    isPending,
+    isSuccess,
+    error,
+  };
+}


### PR DESCRIPTION
Create dataset instructions section and add it to dataset page,

The instructions section contains multiple features: 

- instructions pagination: A group, a page or a list of instructions displayed as list and the user can navigate 
among pages to browse all dataset instructions

- Add new instructions: when the user clicks on the button of "Add instructions" in dataset full card, the form of 
adding new instructions will be opened in instructions section to the user be able to add new instructions.

- Instructions full details: the user has the ability to click on one of the instructions that are displayed in 
the list of instructions to open the full data of this instruction in "selected instruction" part inside instructions section.

- Updating an instruction: when the user clicks on "Edit" icon button in "selected instruction" part inside instructions 
section, the form of updating instructions will be rendered in place of "selected instruction" part and then the user 
be able to updated the the data of the selected instruction.

- Deleting an instruction: in "selected instruction" part inside instructions section, there will be "Delete" icon button, 
when the user clicks on it, an alert window will appear to ask the user to confirm that he really wants to delete 
this selected instruction, then the instruction will be deleted if he confirmed.
