### PR TITLE
Convert the shared parts of tow components to a new reusable components

### DIFF
--- a/src/components/recent-activities/RecentActivitiesList.tsx
+++ b/src/components/recent-activities/RecentActivitiesList.tsx
@@ -1,0 +1,47 @@
+"use client"
+import useRecentActivities from '@/hook/recent-activities/useRecentActivities';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
+import RecentDatasetsActivityCard from './RecentDatasetsActivityCard'
+import { DatabaseZapIcon } from 'lucide-react'
+import RecentDatasetsActivitiesError from './RecentActivitiesError';
+import { Separator } from '../ui/separator';
+import { JSX } from 'react';
+
+type RecentActivitiesListProps = {
+    resource: keyof Activities
+    LoadingListComponent: JSX.Element
+}
+
+export default function RecentActivitiesList({ resource, LoadingListComponent }: RecentActivitiesListProps) {
+
+    const { data, isFetching, error, refetch } = useRecentActivities();
+
+    const activitiesList = data?.[resource];
+    const resourceName = resource === "datasetsActivities" ? "Datasets" : "Instructions";
+
+    return (
+        <Card className='w-full h-full p-3'>
+            <CardHeader className='flex-row gap-2 justify-between items-center space-y-0 pt-3 pb-6 px-0'>
+                <CardTitle className='flex gap-2 items-center'>
+                    <DatabaseZapIcon />
+                    Recent {resourceName} Activities
+                </CardTitle>
+            </CardHeader>
+            <Separator className='mb-2' />
+            <CardContent className="flex flex-col gap-3 p-0 pe-1 h-[425px] sm:h-[550px] overflow-auto">
+                {
+                    isFetching ? LoadingListComponent
+                        : error ? <RecentDatasetsActivitiesError error={error} refetch={refetch} /> :
+                            activitiesList?.length ?
+                                activitiesList.map((act) =>
+                                    <RecentDatasetsActivityCard key={crypto.randomUUID()} activity={act} />
+                                ) : (
+                                    <p className='text-center p-4 text-muted-foreground h-full'>
+                                        No Recent {resourceName} Activities
+                                    </p>
+                                )
+                }
+            </CardContent>
+        </Card>
+    )
+}

--- a/src/components/recent-activities/RecentDatasetsActivities.tsx
+++ b/src/components/recent-activities/RecentDatasetsActivities.tsx
@@ -1,39 +1,12 @@
 "use client"
-import useRecentActivities from '@/hook/recent-activities/useRecentActivities';
-import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
-import RecentDatasetsActivityCard from './RecentDatasetsActivityCard'
-import { DatabaseZapIcon } from 'lucide-react'
 import RecentDatasetsActivitiesLoading from './RecentDatasetsActivitiesLoading';
-import RecentActivitiesError from './RecentActivitiesError';
-import { Separator } from '../ui/separator';
+import RecentActivitiesList from './RecentActivitiesList';
 
 export default function RecentDatasetsActivities() {
-
-    const { data, isFetching, error, refetch } = useRecentActivities();
-
     return (
-        <Card className='w-full h-full p-3'>
-            <CardHeader className='flex-row gap-2 justify-between items-center space-y-0 pt-3 pb-6 px-0'>
-                <CardTitle className='flex gap-2 items-center'>
-                    <DatabaseZapIcon />
-                    Recent Datasets Activities
-                </CardTitle>
-            </CardHeader>
-            <Separator className='mb-2' />
-            <CardContent className="flex flex-col gap-3 p-0 pe-1 h-[425px] sm:h-[550px] overflow-auto">
-                {
-                    isFetching ? <RecentDatasetsActivitiesLoading />
-                        : error ? <RecentActivitiesError error={error} refetch={refetch} /> :
-                            data?.datasetsActivities.length ?
-                                data.datasetsActivities.map((act) =>
-                                    <RecentDatasetsActivityCard key={crypto.randomUUID()} activity={act} />
-                                ) : (
-                                    <p className='text-center p-4 text-muted-foreground h-full'>
-                                        No recent datasets activities
-                                    </p>
-                                )
-                }
-            </CardContent>
-        </Card>
+        <RecentActivitiesList
+            LoadingListComponent={<RecentDatasetsActivitiesLoading />}
+            resource='datasetsActivities'
+        />
     )
 }

--- a/src/components/recent-activities/RecentInstructionsActivities.tsx
+++ b/src/components/recent-activities/RecentInstructionsActivities.tsx
@@ -1,39 +1,13 @@
 "use client"
-import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
-import { CalendarClockIcon } from 'lucide-react'
-import useRecentActivities from '@/hook/recent-activities/useRecentActivities'
-import RecentInstructionsActivityCard from './RecentInstructionsActivityCard'
 import RecentInstructionsActivitiesLoading from './RecentInstructionsActivitiesLoading'
-import RecentActivitiesError from './RecentActivitiesError'
-import { Separator } from '../ui/separator'
+import RecentActivitiesList from './RecentActivitiesList'
 
 export default function RecentInstructionsActivities() {
 
-    const { data, isFetching, error, refetch } = useRecentActivities();
-
     return (
-        <Card className='w-full p-3'>
-            <CardHeader className='flex-row gap-2 justify-between items-center space-y-0 pt-3 pb-6 px-0'>
-                <CardTitle className='flex gap-2 items-center'>
-                    <CalendarClockIcon />
-                    Recent Instructions Activities
-                </CardTitle>
-            </CardHeader>
-            <Separator className='mb-2' />
-            <CardContent className="flex flex-col gap-3 p-0 pe-1 h-[425px] sm:h-[550px] overflow-auto">
-                {
-                    isFetching ? <RecentInstructionsActivitiesLoading /> :
-                        error ? <RecentActivitiesError error={error} refetch={refetch} /> :
-                            data?.instructionsActivities.length ?
-                                data?.instructionsActivities.map((act) =>
-                                    <RecentInstructionsActivityCard key={crypto.randomUUID()} activity={act} />
-                                ) : (
-                                    <p className='p-4 text-muted-foreground h-full flex items-center justify-center'>
-                                        No recent instructions activities
-                                    </p>
-                                )
-                }
-            </CardContent>
-        </Card>
+        <RecentActivitiesList
+            LoadingListComponent={<RecentInstructionsActivitiesLoading />}
+            resource='instructionsActivities'
+        />
     )
 }


### PR DESCRIPTION
Take the shared parts between `RecentDatasetsActivities` and `RecentInstructionsActivities` components ( actually most parts) to create `RecentActivitiesList` component which should be used to build the two components
(`RecentDatasetsActivities` and `RecentInstructionsActivities`).