### PR TITLE
Fire a toast error message when resources deletion failed

### DIFF
--- a/src/hook/datasets/useDeleteDataset.ts
+++ b/src/hook/datasets/useDeleteDataset.ts
@@ -15,6 +15,13 @@ export default function useDeleteDataset() {
         variant: "success",
       });
     },
+    onError(error) {
+      toast({
+        title: "Error while deleting the dataset !",
+        description: error.message,
+        variant: "error",
+      });
+    },
     async mutationFn(dataset: Dataset) {
       const { body } = await fetchAPI(`datasets/${dataset._id}`, {
         method: "DELETE",

--- a/src/hook/instructions/useDeleteInstruction.ts
+++ b/src/hook/instructions/useDeleteInstruction.ts
@@ -22,6 +22,13 @@ export default function useDeleteInstruction({
         variant: "success",
       });
     },
+    onError(error) {
+      toast({
+        title: "Error while deleting the instruction !",
+        description: error.message,
+        variant: "error",
+      });
+    },
     async mutationFn() {
       const { body } = await fetchAPI(`instructions`, {
         method: "DELETE",


### PR DESCRIPTION
Use `onError` option of `useMutation` hook inside `useDeleteDataset` and `useMutation` hooks
to call a function fires a toast when instruction or dataset deletion operation failed.