### PR TITLE
Create a reusable extract cookie function

### DIFF
--- a/src/lib/startExportingDataset.ts
+++ b/src/lib/startExportingDataset.ts
@@ -27,13 +27,7 @@ export default async function startExportingDataset({
 
   const writableStream = await fileHandler.createWritable();
 
-  const sessionToken = document.cookie.split("; ").reduce((acc, cookie) => {
-    const cookieParts = cookie.split("=");
-    if (cookieParts[0] === "__session") {
-      acc = cookieParts[1];
-    }
-    return acc;
-  }, "");
+  const sessionToken = extractCookie("__session");
 
   const baseUrl = process.env.NEXT_PUBLIC_SERVER_WS_BASE_URL;
   const url = `${baseUrl}/ws/export/${datasetId}?format=${format}&auth=${sessionToken}`;

--- a/src/utils/extractCookie.ts
+++ b/src/utils/extractCookie.ts
@@ -1,0 +1,9 @@
+export default function extractCookie(cookieName: string) {
+  return document.cookie.split("; ").reduce((acc, cookie) => {
+    const cookieParts = cookie.split("=");
+    if (cookieParts[0] === cookieName) {
+      acc = cookieParts[1];
+    }
+    return acc;
+  }, "");
+}


### PR DESCRIPTION
Move the function that extracts a cookie from `document.cookie` into a separate file as reusable function.