### PR TITLE
Handle loading states in `DatasetForm` & `DeleteInstructionButton` components

### DIFF
--- a/src/components/datasets/DatasetForm.tsx
+++ b/src/components/datasets/DatasetForm.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from "../ui/button"
 import { DialogTitle } from "../ui/dialog"
 import FetchError from "@/lib/FetchError"
+import { LoaderIcon } from "lucide-react"
 
 type DatasetFormProps = {
     form: any,
@@ -22,7 +23,7 @@ type DatasetFormProps = {
     error: FetchError | null;
 }
 
-export default function DatasetForm({ form, onSubmit, formTitle, formDescription }: DatasetFormProps) {
+export default function DatasetForm({ form, onSubmit, formTitle, formDescription, isLoading }: DatasetFormProps) {
     return (
         <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
@@ -43,7 +44,7 @@ export default function DatasetForm({ form, onSubmit, formTitle, formDescription
                                 <FormItem>
                                     <FormLabel>Name</FormLabel>
                                     <FormControl>
-                                        <Input {...field} />
+                                        <Input {...field} disabled={isLoading || field.disabled} />
                                     </FormControl>
                                     <FormDescription>
                                         This is the name of your dataset.
@@ -61,7 +62,7 @@ export default function DatasetForm({ form, onSubmit, formTitle, formDescription
                                 <FormItem>
                                     <FormLabel>Description</FormLabel>
                                     <FormControl>
-                                        <Textarea {...field} />
+                                        <Textarea {...field} disabled={isLoading || field.disabled} />
                                     </FormControl>
                                     <FormDescription>
                                         This is the description of your dataset
@@ -72,7 +73,20 @@ export default function DatasetForm({ form, onSubmit, formTitle, formDescription
                         />
                     </div>
                 </div>
-                <Button type="submit">Submit</Button>
+                <Button
+                    type="submit"
+                    size="sm"
+                    disabled={isLoading}
+                >
+                    {
+                        isLoading ?
+                            <>
+                                Submitting...
+                                < LoaderIcon size={16} className="ml-2 animate-spin" />
+                            </>
+                            : "Submit"
+                    }
+                </Button>
             </form>
         </Form>
     )

--- a/src/components/datasets/ExportDatasetOptionsForm.tsx
+++ b/src/components/datasets/ExportDatasetOptionsForm.tsx
@@ -11,7 +11,8 @@ import {
     FormMessage
 } from '../ui/form'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
-import useExportDataset, { exportDatasetFormOptions } from '@/hook/datasets/useExportDataset'
+import useExportDataset from '@/hook/datasets/useExportDataset'
+import { exportDatasetFormOptions } from '@/validation/exportDatasetFormOptionsSchemaRules'
 
 export default function ExportDatasetOptionsForm({ dataset }: { dataset: Dataset }) {
 

--- a/src/components/instructions/DeleteInstructionButton.tsx
+++ b/src/components/instructions/DeleteInstructionButton.tsx
@@ -1,4 +1,4 @@
-import { TrashIcon } from 'lucide-react'
+import { LoaderIcon, TrashIcon } from 'lucide-react'
 import ActionWithAlert from '../ActionWithAlert'
 import { Button } from '../ui/button'
 import useDeleteInstruction from '@/hook/instructions/useDeleteInstruction'
@@ -10,7 +10,7 @@ export type DeleteInstructionButtonProps = {
 
 export default function DeleteInstructionButton(props: DeleteInstructionButtonProps) {
 
-    const { deleteTheInstruction } = useDeleteInstruction(props)
+    const { deleteTheInstruction, isPending } = useDeleteInstruction(props)
 
     return (
         <ActionWithAlert
@@ -24,8 +24,12 @@ export default function DeleteInstructionButton(props: DeleteInstructionButtonPr
                     size="icon"
                     variant="destructive"
                     className="size-8"
+                    disabled={isPending}
                 >
-                    <TrashIcon size={17} />
+                    {
+                        isPending ? <LoaderIcon size={17} className="animate-spin" />
+                            : <TrashIcon size={17} />
+                    }
                 </Button>
             }
         />


### PR DESCRIPTION
- Display a loader icon and disable dataset form inputs when the form is submitting (loading state) 
in `DatasetForm` component so that the user can see a feedback when he submitted the form.

- Use `isPending` value from `useDeleteInstruction` hook in `DeleteInstructionButton` component to display 
a loader icon in place of trash icon and disable delete button when deleting process is pending.