### PR TITLE
Cancel the unnecessary  updating the recent activities data

### DIFF
--- a/src/hook/datasets/useDatasetsStatesManagement.ts
+++ b/src/hook/datasets/useDatasetsStatesManagement.ts
@@ -9,8 +9,7 @@ export default function useDatasetsStatesManagement() {
   const { addToDatasetsGrid, deleteFromDatasetsGrid, updateInDatasetsGrid } =
     useDatasetsGridState();
 
-  const { addToRecentDatasetsActivities, updateRecentDatasetsActivities } =
-    useRecentDatasetsActivitiesState();
+  const { addToRecentDatasetsActivities } = useRecentDatasetsActivitiesState();
 
   const { increaseDatasetsCount, decreaseDatasetsCount } =
     useDatasetsOverviewState();
@@ -29,7 +28,6 @@ export default function useDatasetsStatesManagement() {
   function updateDatasetState(updatedDataset: Dataset) {
     updateDataset(updatedDataset._id, updatedDataset);
     updateInDatasetsGrid(updatedDataset);
-    updateRecentDatasetsActivities(updatedDataset._id, updatedDataset);
     addToRecentDatasetsActivities({
       dataset: updatedDataset,
       activity: "Modification",

--- a/src/hook/instructions/useInstructionsStatesManagement.ts
+++ b/src/hook/instructions/useInstructionsStatesManagement.ts
@@ -17,10 +17,8 @@ export default function useInstructionsStatesManagement() {
 
   const { updateInDatasetsGrid } = useDatasetsGridState();
 
-  const {
-    addToRecentInstructionsActivities,
-    updateRecentInstructionsActivities,
-  } = useRecentInstructionsActivitiesState();
+  const { addToRecentInstructionsActivities } =
+    useRecentInstructionsActivitiesState();
 
   function addNewInstructionState(dataset: Dataset, instruction: Instruction) {
     const newActivity: InstructionActivity = {
@@ -60,10 +58,6 @@ export default function useInstructionsStatesManagement() {
       }
       return selected;
     });
-    updateRecentInstructionsActivities(
-      updatedInstruction._id,
-      updatedInstruction
-    );
     addToRecentInstructionsActivities(newActivity);
   }
 

--- a/src/hook/recent-activities/useRecentDatasetsActivitiesState.ts
+++ b/src/hook/recent-activities/useRecentDatasetsActivitiesState.ts
@@ -21,44 +21,7 @@ export default function useRecentDatasetsActivitiesState() {
     );
   }
 
-  function updateRecentDatasetsActivities(
-    datasetId: Dataset["_id"],
-    updateData: Dataset | ((pre?: Dataset) => Dataset)
-  ) {
-    QueryClient.setQueryData<Activities | undefined>(
-      ["recent-activities"],
-      (preData) => {
-        if (preData) {
-          return {
-            datasetsActivities: preData.datasetsActivities.map((activity) => {
-              if (activity.dataset._id === datasetId) {
-                activity.dataset =
-                  typeof updateData === "function"
-                    ? updateData(activity.dataset)
-                    : updateData;
-              }
-              return activity;
-            }),
-            instructionsActivities: preData.instructionsActivities.map(
-              (activity) => {
-                if (activity.dataset._id === datasetId) {
-                  activity.dataset =
-                    typeof updateData === "function"
-                      ? updateData(activity.dataset)
-                      : updateData;
-                }
-                return activity;
-              }
-            ),
-          };
-        }
-        return undefined;
-      }
-    );
-  }
-
   return {
     addToRecentDatasetsActivities,
-    updateRecentDatasetsActivities,
   };
 }

--- a/src/hook/recent-activities/useRecentInstructionsActivitiesState.ts
+++ b/src/hook/recent-activities/useRecentInstructionsActivitiesState.ts
@@ -23,36 +23,7 @@ export default function useRecentInstructionsActivitiesState() {
     );
   }
 
-  function updateRecentInstructionsActivities(
-    instructionId: Instruction["_id"],
-    updateData: Instruction | ((pre?: Instruction) => Instruction)
-  ) {
-    QueryClient.setQueryData<Activities | undefined>(
-      ["recent-activities"],
-      (preData) => {
-        if (preData) {
-          return {
-            ...preData,
-            instructionsActivities: preData.instructionsActivities.map(
-              (activity) => {
-                if (activity.instruction._id === instructionId) {
-                  activity.instruction =
-                    typeof updateData === "function"
-                      ? updateData(activity.instruction)
-                      : updateData;
-                }
-                return activity;
-              }
-            ),
-          };
-        }
-        return preData;
-      }
-    );
-  }
-
   return {
     addToRecentInstructionsActivities,
-    updateRecentInstructionsActivities,
   };
 }


### PR DESCRIPTION
Delete `updateRecentInstructionsActivities` and `updateRecentDatasetsActivities` functions because 
there is no need to update the data of the registered datasets and instructions activities after they 
had been registered.