### PR TITLE
Close "update dataset" form when update operation succeeds

### DIFF
--- a/src/components/datasets/UpdateDatasetForm.tsx
+++ b/src/components/datasets/UpdateDatasetForm.tsx
@@ -2,14 +2,19 @@
 import useUpdateDatasetForm from "@/hook/datasets/useUpdateDatasetForm"
 import DatasetForm from "./DatasetForm"
 
-export default function UpdateDatasetForm({ dataset }: { dataset: Dataset }) {
+type UpdateDatasetFormProps = {
+    dataset: Dataset,
+    closeForm: () => void
+}
+
+export default function UpdateDatasetForm({ dataset, closeForm }: UpdateDatasetFormProps) {
 
     const {
         form,
         onSubmit,
         isPending,
         error,
-    } = useUpdateDatasetForm(dataset);
+    } = useUpdateDatasetForm({ dataset, closeForm });
 
     return (
         <DatasetForm

--- a/src/hook/datasets/useUpdateDatasetForm.ts
+++ b/src/hook/datasets/useUpdateDatasetForm.ts
@@ -21,7 +21,15 @@ type ResponseType = {
   message: string;
 };
 
-export default function useUpdateDatasetForm(dataset: Dataset) {
+type UseUpdateDatasetFormProps = {
+  dataset: Dataset;
+  closeForm: () => void;
+};
+
+export default function useUpdateDatasetForm({
+  dataset,
+  closeForm,
+}: UseUpdateDatasetFormProps) {
   const form = useForm<UpdateDatasetInput>({
     resolver: zodResolver(datasetFormSchema),
     defaultValues: {
@@ -41,6 +49,7 @@ export default function useUpdateDatasetForm(dataset: Dataset) {
   >({
     mutationKey: ["update-dataset"],
     onSuccess(res) {
+      closeForm();
       updateDatasetState(res.data);
       toast({
         title: "Successful dataset update",


### PR DESCRIPTION
Pass `closeForm` prop function (which is the function that supposed to close the opened dialog) to `useUpdateDatasetForm` hook through `UpdateDatasetForm` component to use it to close "update dataset" form when update operation succeeds.